### PR TITLE
Update depdencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,19 +7,18 @@
     "asciinema-selfhost": "cli.js"
   },
   "dependencies": {
-    "cheerio": "^0.19.0",
+    "cheerio": "^1.0.0-rc.12",
     "cpr": "^0.4.1",
     "fs-extra": "^0.22.1",
     "ipfs-api": "^12.1.7",
     "mkdirp": "^0.5.1",
     "node-dom": "^0.1.0",
-    "optimist": "^0.6.1",
+    "optimist": "^0.5.2",
     "request": "^2.58.0",
     "tmp": "0.0.31",
     "vinyl": "^0.5.0",
-    "vinyl-fs": "^1.0.0"
+    "vinyl-fs": "^2.4.1"
   },
-  "devDependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Fixes this error

```
$ node --version
v16.17.0
$ node cli.js 
fs.js:47
} = primordials;
    ^

ReferenceError: primordials is not defined
    at fs.js:47:5
    at req_ (/home/chiller/Desktop/git/asciinema-selfhost/node_modules/natives/index.js:143:24)
    at Object.req [as require] (/home/chiller/Desktop/git/asciinema-selfhost/node_modules/natives/index.js:55:10)
    at Object.<anonymous> (/home/chiller/Desktop/git/asciinema-selfhost/node_modules/vinyl-fs/node_modules/graceful-fs/fs.js:1:37)
    at Module._compile (node:internal/modules/cjs/loader:1126:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1180:10)
    at Module.load (node:internal/modules/cjs/loader:1004:32)
    at Function.Module._load (node:internal/modules/cjs/loader:839:12)
    at Module.require (node:internal/modules/cjs/loader:1028:19)
    at require (node:internal/modules/cjs/helpers:102:18)
```